### PR TITLE
ref: get the binaries from samora-lang official repository

### DIFF
--- a/.github/workflows/install.unix.yaml
+++ b/.github/workflows/install.unix.yaml
@@ -1,0 +1,25 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Unix-Installer
+
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+jobs:
+  installation_test:
+    name: samora-lang installation test.
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo sh ./Unix/installer.sh
+      - run: samora --help

--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@ I really recommend installing golang in your host, although it is not mandatory.
 
 ### Linux
 
-For **any** Linux distribution, you just need to make sure you have [curl](https://curl.se/) installed, and just run the following command to install samora-lang
+#### Pre-requisites
+
+- [jq](https://jqlang.github.io/jq/download/)
+- [curl](https://curl.se)
+
+using `curl`:
 
 ```bash
 sudo curl -sSL https://raw.githubusercontent.com/obadiaspelembe/samora-lang-installers/main/Unix/installer.sh | bash
 ```
 
-You can also install using [wget](https://www.gnu.org/software/wget/)
+You can also install using [wget](https://www.gnu.org/software/wget/), but need to make sure you have the <a href="#pre-requisites">pre-requisites</a> installed!
 
 ```bash
 sudo wget -O - https://raw.githubusercontent.com/obadiaspelembe/samora-lang-installers/main/Unix/installer.sh | bash

--- a/Unix/installer.sh
+++ b/Unix/installer.sh
@@ -6,13 +6,13 @@ command_exists() {
 
 # Check if curl is installed
 if ! command_exists curl; then
-  echo "install 'curl' to proceed"
+  echo "install curl to proceed"
   echo "exiting..."
   exit
 fi
 
 if ! command_exists jq; then
-  echo "install 'jq' at: https://jqlang.github.io/jq/download/ to proceed"
+  echo "install jq at: https://jqlang.github.io/jq/download/ to proceed"
   echo "exiting..."
   exit
 fi

--- a/Unix/installer.sh
+++ b/Unix/installer.sh
@@ -6,13 +6,19 @@ command_exists() {
 
 # Check if curl is installed
 if ! command_exists curl; then
-  echo "install curl to proceed"
+  echo "install 'curl' to proceed"
   echo "exiting..."
   exit
 fi
 
-if ! command_exists samora; then
-  sudo mv $(which samora)
+if ! command_exists jq; then
+  echo "install 'jq' at: https://jqlang.github.io/jq/download/ to proceed"
+  echo "exiting..."
+  exit
+fi
+
+if command_exists samora; then
+  sudo rm $(which samora)
 fi
 
 temp_dir=$(mktemp -d)
@@ -34,7 +40,7 @@ tar -xzf ./${LATEST_VERSION_FILE_NAME}
 
 sudo cp samora-lang /usr/local/bin/samora
 
-chmod +x /usr/local/bin/samora
+sudo chmod +x /usr/local/bin/samora
 
 if command_exists samora; then
   echo "Delete temporary directory..."

--- a/Unix/installer.sh
+++ b/Unix/installer.sh
@@ -21,6 +21,15 @@ if command_exists samora; then
   sudo rm $(which samora)
 fi
 
+NAME=$(uname -s)
+
+if [ "$NAME" = "Darwin" ]; then
+  PLATFORM='darwin'
+else
+  PLATFORM='linux'
+fi
+
+
 temp_dir=$(mktemp -d)
 echo "Temporary directory: $temp_dir"
 
@@ -28,7 +37,7 @@ LATEST_SML_RELEASE=$(curl -s https://api.github.com/repos/GraHms/Samora-Lang/rel
 
 LATEST_SML_VERSION=$(echo $LATEST_SML_RELEASE | jq -r '.tag' | sed 's/^v//')
 
-LATEST_VERSION_FILE_NAME=$(echo "samora-lang_${LATEST_SML_VERSION}_linux_amd64.tar.gz")
+LATEST_VERSION_FILE_NAME=$(echo "samora-lang_${LATEST_SML_VERSION}_${PLATFORM}_amd64.tar.gz")
 
 LATEST_SML_FILE_URL=$(echo $LATEST_SML_RELEASE | jq -r '.assets[] .browser_download_url' | grep $LATEST_VERSION_FILE_NAME)
 


### PR DESCRIPTION
This PR gets directly the binary from assets of the latest release on the samora-lang's official repository, instead of installing go and then build the binary.

#### BUGs FIXED:
- Crash when using a non-debian-based distro when go is not installed, 'cuz the last version use to use `apt` to get `go`